### PR TITLE
Fix: Improve M3U generator workflow and script robustness

### DIFF
--- a/autorun.sh
+++ b/autorun.sh
@@ -6,6 +6,6 @@ python3 -m pip install requests
 
 cd $(dirname $0)/scripts/
 
-python3 youtube_m3ugrabber.py > ../youtube.m3u
+python3 youtube_m3ugrabber.py
 
 echo m3u grabbed

--- a/scripts/youtube_m3ugrabber.py
+++ b/scripts/youtube_m3ugrabber.py
@@ -50,7 +50,9 @@ def main():
     global s
     s = requests.Session()
     
-    with open('../youtube_channel_info.txt') as f:
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    info_file_path = os.path.join(script_dir, '..', 'youtube_channel_info.txt')
+    with open(info_file_path) as f:
         with open('../youtube.m3u', 'w') as output_file:
             print('#EXTM3U x-tvg-url="https://github.com/botallen/epg/releases/download/latest/epg.xml.gz"', file=output_file)
             


### PR DESCRIPTION
This commit addresses potential build errors in the M3U generator workflow:

1.  Removed output redirection in `autorun.sh`: The Python script `youtube_m3ugrabber.py` already handles writing the `youtube.m3u` file to the correct location (`../youtube.m3u` relative to the script). Removing the redirection in `autorun.sh` simplifies the script and ensures that any errors from the Python script are surfaced in the GitHub Actions logs.

2.  Made file path for `youtube_channel_info.txt` in `youtube_m3ugrabber.py` more robust: The script now constructs an absolute path to `youtube_channel_info.txt` based on its own location. This prevents issues if the script is called from a different working directory.

These changes aim to resolve the build errors and improve the reliability of the M3U generation process.