### PR TITLE
Fix: Grant write permissions to workflow for git push

### DIFF
--- a/.github/workflows/m3u_Generator.yml
+++ b/.github/workflows/m3u_Generator.yml
@@ -20,7 +20,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
This commit updates the `.github/workflows/m3u_Generator.yml` file to grant `contents: write` permission to the build job. This is necessary for the `git push` command in the `commit & push` step to succeed when the workflow is triggered by events such as schedules or manual dispatches on the main repository.

Note: For pull requests originating from forks, the `git push` step in the workflow might still encounter permission issues. The standard `GITHUB_TOKEN` has read-only permissions in such contexts for security reasons. The typical approach for contributions from forks is for the changes to be pushed to the fork and then merged into the main repository via the pull request normally.